### PR TITLE
Fix tile's region y calculation when tiles are not squared.

### DIFF
--- a/src/level.cpp
+++ b/src/level.cpp
@@ -127,7 +127,7 @@ void level::load(const std::string& path, SDL_Renderer* ren) {
 
                 // Calculate the area on the tilesheet to draw from.
                 auto region_x = (cur_gid % (ts_width / tile_width)) * tile_width;
-                auto region_y = (cur_gid / (ts_width / tile_height)) * tile_height;
+                auto region_y = (cur_gid / (ts_width / tile_width)) * tile_height;
 
                 // Calculate the world position of our tile. This is easy,
                 // because we're using nested for-loop to visit each x,y


### PR DESCRIPTION
The tile's region in the Y axis won't be calculated correctly if tiles are not squared `(tile_width != tile_height)`.
We need to switch to a new Y row when `(ts_width / tile_width)` division increases, not `(ts_width / tile_height)`.